### PR TITLE
Custom Image to make Dependencies Work

### DIFF
--- a/beets/Dockerfile
+++ b/beets/Dockerfile
@@ -1,0 +1,4 @@
+FROM lscr.io/linuxserver/beets:latest
+
+# Install the required Python packages for the audible plugin
+RUN pip install natsort markdownify

--- a/beets/docker-compose.yml
+++ b/beets/docker-compose.yml
@@ -1,17 +1,21 @@
 version: "3"
 services:
   beets:
-    image: lscr.io/linuxserver/beets:latest
+    # Use 'beets-custom:latest' if building the Dockerfile in this repo,
+    # otherwise use 'lscr.io/linuxserver/beets:latest' and enable EXTRA_PIPS.
+    image: beets-custom:latest # <--- Updated to use the custom image
     container_name: beets
     environment:
-      # Update as needed
-      - PUID=1000
-      - PGID=1000
-      - TZ=Asia/Singapore
+      - PUID=1000 # Your User ID
+      - PGID=1000 # Your Group ID
+      - TZ=America/New_York # Your Timezone (e.g., Asia/Singapore, America/New_York)
+      # - EXTRA_PIPS=natsort markdownify # This line can be removed if using the custom image build
     volumes:
       - ./config:/config
       - ./plugins:/plugins
-      - ./scripts:/config/custom-cont-init.d
-      - /path/to/plex/audiobooks:/audiobooks
-      - /path/to/temp/untagged:/untagged
+      # If you're using custom init scripts (like install-deps.sh), uncomment the line below.
+      # However, for robust dependency installation, building a custom image (as above) is recommended.
+      # - ./scripts:/config/custom-cont-init.d
+      - /path/to/plex/audiobooks:/audiobooks # Path to your audiobook library
+      - /path/to/temp/untagged:/untagged # Path for untagged/new files
     restart: unless-stopped

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# Beets-audible: Organize Your Audiobook Collection With Beets
+# Beets-audible: Organize Your Audiobook Collection With Beets Working 2025
+Fork of the Fork of Seanap's beets-audible plugin,  https://github.com/seanap/beets-audible , working 2025!
+
 This is my fork of the awesome Beets-Audible plug-in made by Neurrone https://github.com/Neurrone/beets-audible
 
 This is a plugin that allows Beets to manage audiobook collections.

--- a/readme.md
+++ b/readme.md
@@ -19,22 +19,51 @@ This was developed to handle book files with no tags, bad tags, or that need to 
 
 ### With Docker
 
-1. `git clone https://github.com/seanap/beets-audible.git` # Open a terminal and clone this repository  
-2. `nano beets-audible/beets/docker-compose.yml` # Edit `docker-compose.yml`  
-    * Update the following lines:
-      * `PUID`
-      * `PGID`
-      * `TZ`
+1.  **Clone the Repository:**
+    ```bash
+    git clone [https://github.com/AlexNaglich/beets-audible.git](https://github.com/AlexNaglich/beets-audible.git)
+    ```
+    This is now your "root" for this project
+
+2.  **Build Your Custom Beets Image:**
+
+    This step ensures all necessary Python dependencies (`natsort`, `markdownify`) for the `audible` plugin are reliably installed.
+    ```bash
+    cd beets-audible/beets
+    docker build -t beets-custom:latest .
+    ```
+
+3.  **Configure Docker Compose (`docker-compose.yml`):**
+
+    `nano beets-audible/beets/docker-compose.yml`
+
+    * Update `PUID`, `PGID`, `TZ`, and your volume paths
       * `/path/to/plex/audibooks` # Location of your plex audiobooks folder
       * `/path/to/temp/untagged` # Location of Untagged books ready for tagging
-3. `nano beets-audible/beets/config/config.yaml` # Edit `config.yaml`  
-    * Update the `Plex` section at the end of the file:
+
+4.  **Configure Beets Config (`config/config.yaml`):**
+
+    `nano beets-audible/beets/config/config.yaml`
+
+    Edit `config/config.yaml` to update your Plex details (`host`, `token`, `library_name`) under the `plexupdate` section.
       * `host` # IP of plex server
       * `token` # https://support.plex.tv/hc/en-us/articles/204059436-Finding-your-account-token-X-Plex-Token
       * `library_name` # Name of plex audiobook library
-4. `cd beets-audible/beets && docker-compose up -d` # Start the container
-7. `docker exec -it beets sh` # Start the interactive shell inside the beets container
-8. `beet --version` # Verify that the audible plugin appears in the list of plugins.
+
+5.  **Start and Verify:**
+
+    Stop any old containers and start the new one:
+    ```bash
+    cd beets-audible/beets
+    docker compose down --volumes --remove-orphans
+    docker compose up -d
+    ```
+    Verify the `audible` plugin is loading:
+    ```bash
+    docker exec -it beets sh -c 'beet --version'
+    ```
+    You should see `audible` listed in the plugins.
+
 
 ## Usage
 


### PR DESCRIPTION
Added step to use custom image build, improving dependency installation success. This fixed issues I was facing with getting the tool to work. 
 
 Updated Installation Instructions